### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# colab
+# Colab Notebooks
+
+This repository contains example notebooks for various tasks. Run the setup script to install the required dependencies on a fresh system.
+
+## Setup
+
+```bash
+bash setup.sh
+```
+
+The script installs system packages and Python libraries needed for the notebooks.
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+# Install system dependencies
+sudo apt-get update
+sudo apt-get install -y libcudnn8 aria2
+
+# Install Python dependencies used in notebooks
+pip install --upgrade torch torchvision
+pip install realesrgan gfpgan basicsr
+pip install "audio-separator[gpu]==0.32.0" demucs aria2 yt_dlp
+
+echo "Setup complete."
+


### PR DESCRIPTION
## Summary
- add a setup.sh script to install apt and pip dependencies
- update README with instructions for using the setup script

## Testing
- `bash -n setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867648626d4833292d35af888e020c8