### PR TITLE
feat: improve photo restoration pipeline

### DIFF
--- a/photo-restoration-pipeline/inference.py
+++ b/photo-restoration-pipeline/inference.py
@@ -1,41 +1,66 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import numpy as np
 import torch
 from PIL import Image
-from torchvision.transforms import ToTensor, ToPILImage
-from mirnet.model import MIRNet
 from basicsr.archs.rrdbnet_arch import RRDBNet
 from realesrgan import RealESRGANer
-import numpy as np
+from torchvision.transforms import ToPILImage, ToTensor
+
+from mirnet.model import MIRNet
 
 
-def main():
-    input_img = Image.open("input/sample.jpg").convert("RGB")
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run photo restoration pipeline")
+    parser.add_argument(
+        "--mirnet-weights",
+        type=Path,
+        default=Path("mirnet") / "weights" / "mirnet_finetuned.pth",
+        help="Path to MIRNet weights",
+    )
+    parser.add_argument(
+        "--esrgan-weights",
+        type=Path,
+        default=Path("realesrgan") / "weights" / "RealESRGAN_x4plus.pth",
+        help="Path to Real-ESRGAN weights",
+    )
+    return parser.parse_args()
 
-    # Stage 1: MIRNet enhancement
-    mirnet = MIRNet().eval()
-    if torch.cuda.is_available():
-        mirnet = mirnet.cuda()
-    state = torch.load("mirnet/weights/mirnet_finetuned.pth", map_location="cpu")
+
+def run_inference(mirnet_weights: Path, esrgan_weights: Path) -> None:
+    input_img = Image.open(Path("input") / "sample.jpg").convert("RGB")
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    mirnet = MIRNet().eval().to(device)
+    state = torch.load(mirnet_weights, map_location="cpu")
     if "model_state_dict" in state:
         state = state["model_state_dict"]
     mirnet.load_state_dict(state)
-    x = ToTensor()(input_img).unsqueeze(0)
-    if torch.cuda.is_available():
-        x = x.cuda()
+
+    x = ToTensor()(input_img).unsqueeze(0).to(device)
     with torch.no_grad():
         y = mirnet(x).clamp(0, 1)
-    stage1_img = ToPILImage()(y.squeeze().cpu())
-    stage1_img.save("output/stage1_mirnet.png")
 
-    # Stage 2: Real-ESRGAN upscale + denoise
+    output_dir = Path("output")
+    output_dir.mkdir(exist_ok=True)
+    stage1_img = ToPILImage()(y.squeeze().cpu())
+    stage1_path = output_dir / "stage1_mirnet.png"
+    stage1_img.save(stage1_path)
+
     model = RRDBNet(3, 3, 64, 23, 32, scale=4)
     up = RealESRGANer(
-        scale=4,
-        model_path="realesrgan/weights/RealESRGAN_x4plus.pth",
-        model=model,
-        device=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+        scale=4, model_path=str(esrgan_weights), model=model, device=device
     )
     output, _ = up.enhance(np.array(stage1_img), outscale=4)
-    Image.fromarray(output).save("output/final_output.png")
+    Image.fromarray(output).save(output_dir / "final_output.png")
+
+
+def main() -> None:
+    args = parse_args()
+    run_inference(args.mirnet_weights, args.esrgan_weights)
 
 
 if __name__ == "__main__":

--- a/photo-restoration-pipeline/mirnet/model.py
+++ b/photo-restoration-pipeline/mirnet/model.py
@@ -1,15 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
 import torch
 from torch import nn
 
 
 class MIRNet(nn.Module):
-    """Skeleton MIRNet model for low-light image enhancement."""
+    """Minimal MIRNet stub."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
-        # TODO: Add full MIRNet architecture implementation
-        self.layer = nn.Identity()
+        # TODO: build actual MIRNet layers
+        self.layer: nn.Module = nn.Identity()
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """Forward pass placeholder."""
+        """Return input tensor until model is implemented."""
         return self.layer(x)
+
+    def load_pretrained(
+        self, weights_path: Path
+    ) -> None:  # pragma: no cover - placeholder
+        """Load pretrained weights (not yet implemented)."""
+        raise NotImplementedError("Pretrained weights loading not implemented")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,17 +1,13 @@
-# — Core deep-learning stack —
-torch==2.1.2+cu121          # unified CUDA 12.1 wheel, ~255 MB
-torchvision==0.16.2+cu121   # matching vision wheel
 --extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.2.2+cu121
+torchvision==0.17.2+cu121
+torchaudio==2.2.2+cu121
 
-
-
-# — Image processing —
 opencv-python-headless>=4.8.0
-
-# — MIRNet + Real-ESRGAN dependencies —
-basicsr-fixed==1.4.2   # latest available wheel
+basicsr-fixed==1.4.2
 facexlib>=0.2.0
 gfpgan>=1.3.8
 huggingface_hub>=0.21.4
 scikit-image>=0.22.0
 tqdm>=4.66.0
+pytest>=8.0.0

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Upgrade packaging tools
+pip install --upgrade pip wheel
+
 # Install system dependencies
 sudo apt-get update
 sudo apt-get install -y libcudnn8 aria2
@@ -9,6 +12,11 @@ sudo apt-get install -y libcudnn8 aria2
 pip install --upgrade torch torchvision
 pip install realesrgan gfpgan basicsr
 pip install "audio-separator[gpu]==0.32.0" demucs aria2 yt_dlp
+
+# Install repo requirements if available
+if [ -f requirements.txt ]; then
+    pip install -r requirements.txt --quiet --retries 3 --timeout 120
+fi
 
 echo "Setup complete."
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,0 +1,41 @@
+import sys
+import types
+import runpy
+
+import pytest
+
+
+def dummy_module(**attrs):
+    mod = types.ModuleType("dummy")
+    for k, v in attrs.items():
+        setattr(mod, k, v)
+    return mod
+
+
+def test_help(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(
+        sys.modules,
+        "torch",
+        dummy_module(
+            cuda=dummy_module(is_available=lambda: False),
+            device=lambda *a, **k: None,
+            load=lambda *a, **k: {},
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "numpy", dummy_module())
+    monkeypatch.setitem(sys.modules, "PIL", dummy_module(Image=object))
+    monkeypatch.setitem(
+        sys.modules,
+        "torchvision.transforms",
+        dummy_module(ToTensor=lambda: None, ToPILImage=lambda: None),
+    )
+    monkeypatch.setitem(
+        sys.modules, "basicsr.archs.rrdbnet_arch", dummy_module(RRDBNet=object)
+    )
+    monkeypatch.setitem(sys.modules, "realesrgan", dummy_module(RealESRGANer=object))
+    monkeypatch.setitem(sys.modules, "mirnet.model", dummy_module(MIRNet=object))
+
+    monkeypatch.setattr(sys, "argv", ["inference.py", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        runpy.run_path("photo-restoration-pipeline/inference.py", run_name="__main__")
+    assert exc.value.code == 0


### PR DESCRIPTION
## Summary
- update top-level requirements with CUDA 12 wheels
- harden setup script to upgrade pip and install requirements when present
- refactor inference script to use CLI weight paths and pathlib
- provide a simple MIRNet stub for now
- add a basic pytest sanity test

## Test Plan
- `pip install -r requirements.txt` *(fails: incomplete download)*
- `python photo-restoration-pipeline/inference.py --help` *(fails: No module named 'numpy')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68696bdf4b608332a43117a5e1bc1cbd