### PR TITLE
feat: drop realesrgan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ All files under this repository.
 2. PR body must list affected modules and a test plan.
 
 ## Data-Flow Overview
-`raw_image` ➡ **MIRNet** ➡ `stage1_out` ➡ **Real-ESRGAN** ➡ `final_out` (shown inline).
+`raw_image` ➡ **MIRNet** ➡ `final_out` (shown inline).
 
 ## Deferred Features
 - SwinIR refinement

--- a/Advanced_Photo_Restoration.ipynb
+++ b/Advanced_Photo_Restoration.ipynb
@@ -16,8 +16,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install torch torchvision --upgrade\n",
-    "!pip install realesrgan gfpgan basicsr"
+     "!pip install torch torchvision --upgrade\n",
+     "!pip install gfpgan basicsr"
    ]
   },
   {
@@ -29,11 +29,7 @@
    "source": [
     "import os\n",
     "os.makedirs('weights', exist_ok=True)\n",
-    "model_path = 'weights/RealESRGAN_x4plus.pth'\n",
-    "if not os.path.isfile(model_path):\n",
-    "    !wget -q https://github.com/xinntao/Real-ESRGAN/releases/download/v0.1.0/RealESRGAN_x4plus.pth -O {model_path}\n",
-    "\n",
-    "swinir_path = 'weights/SwinIR-M_x4.pth'\n",
+     "swinir_path = 'weights/SwinIR-M_x4.pth'\n",
     "if not os.path.isfile(swinir_path):\n",
     "    !wget -q https://github.com/JingyunLiang/SwinIR/releases/download/v0.0/001_classicalSR_DIV2K_s48w8_SwinIR-M_x4.pth -O {swinir_path}"
    ]
@@ -82,38 +78,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c24cf942",
-   "metadata": {},
-   "source": [
-    "### Stage 2: Upscaling & Denoising (Real-ESRGAN)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be35bd46",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from realesrgan import RealESRGAN\n",
-    "from PIL import Image\n",
-    "import numpy as np\n",
-    "\n",
-    "device = torch.device('cuda')\n",
-    "model = RealESRGAN(device, scale=4)\n",
-    "model.load_weights('weights/RealESRGAN_x4plus.pth')\n",
-    "\n",
-    "pil_lr = Image.fromarray(cv2.cvtColor(enhanced_img, cv2.COLOR_BGR2RGB))\n",
-    "sr_pil = model.predict(pil_lr)\n",
-    "sr_img = cv2.cvtColor(np.array(sr_pil), cv2.COLOR_RGB2BGR)\n",
-    "\n",
-    "_, enc = cv2.imencode('.png', sr_img)\n",
-    "display(IPImage(data=enc.tobytes(), format='png'))\n",
-    "torch.cuda.empty_cache()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "f0cad255",
    "metadata": {},
    "source": [
@@ -129,7 +93,7 @@
    "source": [
     "import numpy as np\n",
     "kernel = np.array([[0, -1, 0],[-1, 5,-1],[0, -1, 0]], np.float32)\n",
-    "refined_img = cv2.filter2D(sr_img, -1, kernel)\n",
+     "refined_img = cv2.filter2D(enhanced_img, -1, kernel)\n",
     "\n",
     "_, enc = cv2.imencode('.png', refined_img)\n",
     "display(IPImage(data=enc.tobytes(), format='png'))\n",
@@ -141,7 +105,7 @@
    "id": "e9b3716e",
    "metadata": {},
    "source": [
-    "This notebook enhances a low-quality photo through brightness correction, upscaling+denoising, and optional sharpening, using pretrained models cached in the `weights/` directory."
+     "This notebook enhances a low-quality photo through brightness correction and optional sharpening, using pretrained models cached in the `weights/` directory."
    ]
   }
  ],

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -9,12 +9,6 @@ python -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip wheel
 pip install -r requirements.txt
-
-Extra steps
-
-# Clone & editable-install Real-ESRGAN
-git clone https://github.com/xinntao/Real-ESRGAN.git
-pip install -e Real-ESRGAN --use-pep517
 ```
 
-The requirements.txt pins torch>=2.1, torchvision>=0.16, basicsr-fixed>=1.4.3, plus other libs needed for MIRNet and Real-ESRGAN.
+The requirements.txt pins torch>=2.1, torchvision>=0.16, basicsr-fixed>=1.4.3, plus other libs needed for MIRNet.

--- a/photo-restoration-pipeline/.gitignore
+++ b/photo-restoration-pipeline/.gitignore
@@ -1,4 +1,3 @@
 # Ignore heavy weight files
 mirnet/weights/*.pth
-realesrgan/
 output/

--- a/photo-restoration-pipeline/README.md
+++ b/photo-restoration-pipeline/README.md
@@ -1,17 +1,13 @@
 # Photo Restoration Pipeline
 
-This project provides a two-stage pipeline for restoring low-quality photographs.
-It first enhances images using **MIRNet** and then upsamples them with
-**Real-ESRGAN**.
+This project provides a simple pipeline for restoring low-quality photographs using **MIRNet** only.
 
 ## Usage
 
-Install dependencies and clone the Real-ESRGAN repository:
+Install dependencies:
 
 ```bash
 pip install -r requirements.txt
-# Clone Real-ESRGAN inside the `realesrgan/` directory if not already present
-# git clone https://github.com/xinntao/Real-ESRGAN.git realesrgan
 ```
 
 Run the inference script:

--- a/photo-restoration-pipeline/inference.py
+++ b/photo-restoration-pipeline/inference.py
@@ -3,11 +3,8 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-import numpy as np
 import torch
 from PIL import Image
-from basicsr.archs.rrdbnet_arch import RRDBNet
-from realesrgan import RealESRGANer
 from torchvision.transforms import ToPILImage, ToTensor
 
 from mirnet.model import MIRNet
@@ -21,16 +18,10 @@ def parse_args() -> argparse.Namespace:
         default=Path("mirnet") / "weights" / "mirnet_finetuned.pth",
         help="Path to MIRNet weights",
     )
-    parser.add_argument(
-        "--esrgan-weights",
-        type=Path,
-        default=Path("realesrgan") / "weights" / "RealESRGAN_x4plus.pth",
-        help="Path to Real-ESRGAN weights",
-    )
     return parser.parse_args()
 
 
-def run_inference(mirnet_weights: Path, esrgan_weights: Path) -> None:
+def run_inference(mirnet_weights: Path) -> None:
     input_img = Image.open(Path("input") / "sample.jpg").convert("RGB")
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
@@ -46,21 +37,13 @@ def run_inference(mirnet_weights: Path, esrgan_weights: Path) -> None:
 
     output_dir = Path("output")
     output_dir.mkdir(exist_ok=True)
-    stage1_img = ToPILImage()(y.squeeze().cpu())
-    stage1_path = output_dir / "stage1_mirnet.png"
-    stage1_img.save(stage1_path)
-
-    model = RRDBNet(3, 3, 64, 23, 32, scale=4)
-    up = RealESRGANer(
-        scale=4, model_path=str(esrgan_weights), model=model, device=device
-    )
-    output, _ = up.enhance(np.array(stage1_img), outscale=4)
-    Image.fromarray(output).save(output_dir / "final_output.png")
+    output_img = ToPILImage()(y.squeeze().cpu())
+    output_img.save(output_dir / "final_output.png")
 
 
 def main() -> None:
     args = parse_args()
-    run_inference(args.mirnet_weights, args.esrgan_weights)
+    run_inference(args.mirnet_weights)
 
 
 if __name__ == "__main__":

--- a/photo-restoration-pipeline/notebook.ipynb
+++ b/photo-restoration-pipeline/notebook.ipynb
@@ -4,8 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Photo Restoration Pipeline\n",
-    "This notebook demonstrates running MIRNet and Real-ESRGAN in Colab."
+     "# Photo Restoration Pipeline\n",
+     "This notebook demonstrates running MIRNet in Colab."
    ]
   },
   {
@@ -19,19 +19,9 @@
    "cell_type": "code",
    "metadata": {},
    "source": [
-    "# Clone Real-ESRGAN if necessary\n",
-    "!git clone https://github.com/xinntao/Real-ESRGAN.git realesrgan"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "metadata": {},
-   "source": [
     "from PIL import Image\n",
     "from mirnet.model import MIRNet\n",
-    "from basicsr.archs.rrdbnet_arch import RRDBNet\n",
-    "from realesrgan import RealESRGANer\n",
-    "import torch, numpy as np"
+    "import torch"
    ]
   }
  ],

--- a/setup.sh
+++ b/setup.sh
@@ -10,7 +10,7 @@ sudo apt-get install -y libcudnn8 aria2
 
 # Install Python dependencies used in notebooks
 pip install --upgrade torch torchvision
-pip install realesrgan gfpgan basicsr
+pip install gfpgan basicsr
 pip install "audio-separator[gpu]==0.32.0" demucs aria2 yt_dlp
 
 # Install repo requirements if available

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -22,17 +22,12 @@ def test_help(monkeypatch: pytest.MonkeyPatch) -> None:
             load=lambda *a, **k: {},
         ),
     )
-    monkeypatch.setitem(sys.modules, "numpy", dummy_module())
     monkeypatch.setitem(sys.modules, "PIL", dummy_module(Image=object))
     monkeypatch.setitem(
         sys.modules,
         "torchvision.transforms",
         dummy_module(ToTensor=lambda: None, ToPILImage=lambda: None),
     )
-    monkeypatch.setitem(
-        sys.modules, "basicsr.archs.rrdbnet_arch", dummy_module(RRDBNet=object)
-    )
-    monkeypatch.setitem(sys.modules, "realesrgan", dummy_module(RealESRGANer=object))
     monkeypatch.setitem(sys.modules, "mirnet.model", dummy_module(MIRNet=object))
 
     monkeypatch.setattr(sys, "argv", ["inference.py", "--help"])


### PR DESCRIPTION
## Summary
- remove Real-ESRGAN from the photo restoration pipeline
- clean up notebooks and docs
- update environment and setup scripts

## Test Plan
- `black -l 120 photo-restoration-pipeline/inference.py tests/test_inference.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a05a6cd488332be2ce6552f602bc1